### PR TITLE
Academy  - syntax fix for python 3.8

### DIFF
--- a/src/fv3jeditools/utils.py
+++ b/src/fv3jeditools/utils.py
@@ -245,7 +245,7 @@ def wait_for_batch_job(username, jobname):
             print(squeue_result)
             print_job = False
 
-        if squeue_result is '':
+        if squeue_result == '':
             job_finished = True
             print(' Slurm job is finished')
             break


### PR DESCRIPTION
## Description

The containers for the academy use python 3.8.  They give a warning:
```
Singularity> fv3jeditools.x --help
/home/ubuntu/jedi/fv3-jedi-tools/src/fv3jeditools/utils.py:248: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if squeue_result is '':
Usage: fv3jeditools.x [OPTIONS] ISODATETIME CONFIG

Options:
  --help  Show this message and exit.
```

This fixes that warning


### Issue(s) addressed



## Dependencies



## Impact


