### PR TITLE
Plot convergence for block minimizer

### DIFF
--- a/src/Workflows/Generic/Diagnostics/da_block_convergence.yaml
+++ b/src/Workflows/Generic/Diagnostics/da_block_convergence.yaml
@@ -1,0 +1,16 @@
+application:
+
+  # Application to use
+  application name: da_block_convergence
+
+  # JEDI EDA log file to read
+  log file: /gpfsm/dnb31/drholdaw/JediWF/fv3-jedi-tools-testing/<block log file>
+
+  # Number of members in the EDA
+  members: 4
+
+  # Yscale for figures (log or linear)
+  yscale: linear
+
+  # Output format for plots (png or pdf)
+  plot format: pdf

--- a/src/fv3jeditools/__init__.py
+++ b/src/fv3jeditools/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)
 
+from .diag_da_block_convergence import *
 from .diag_da_convergence import *
 from .diag_field_plot import *
 from .diag_hofx_innovations import *

--- a/src/fv3jeditools/diag_da_block_convergence.py
+++ b/src/fv3jeditools/diag_da_block_convergence.py
@@ -1,0 +1,157 @@
+# (C) Copyright 2021 UCAR
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+import matplotlib.pyplot as plt
+import numpy as np
+import os
+import re
+
+import fv3jeditools.utils as utils
+
+# --------------------------------------------------------------------------------------------------
+## @package da_block_convergence
+#
+#  This application can be triggered by using "application name: da_block_convergence"
+#
+#  Configuration options:
+#  ----------------------
+#  log file    | The log file to parse the statistics from
+#  yscale      | Whether to use log or linear scale for the yaxis
+#  plot format | The extension used for the file name, png or pdf
+#
+#
+#  This function takes a yaml file configuration as well as a datetime. It will plot the convergence
+#  statistics from the log of a variational data assimilation run, provided through the yaml.
+#  It will search for the Minimizer norm gradient, J, Jb, JoJc and GMRESR
+#
+#
+# --------------------------------------------------------------------------------------------------
+
+def da_block_convergence(datetime, conf):
+
+    # Log file to parse
+    try:
+        log_file = conf['log file']
+    except:
+        utils.abort('\'log file\' must be present in the configuration')
+
+    # Get output path for plots
+    try:
+        output_path = conf['output path']
+    except:
+        output_path = './'
+
+    # Create output path
+    if not os.path.exists(output_path):
+        os.makedirs(output_path)
+
+    # Replace datetime in logfile name
+    isodatestr = datetime.strftime("%Y-%m-%dT%H:%M:%S")
+    log_file = utils.stringReplaceDatetimeTemplate(isodatestr, log_file)
+
+
+    # Read file and gather norm information
+    print(" Reading convergence from ", log_file)
+    print("This is the block version")
+
+    # Open the file ready for reading
+    if os.path.exists(log_file):
+        file = open(log_file, "r")
+    else:
+        utils.abort('Log file not found.')
+
+
+    # Search for the type of minimizer used for the assimilation
+    for line in file:
+        if "Minimizer algorithm=" in line:
+            minimizer = line.split('=')[1].rstrip()
+            break
+
+
+    # Patterns to search for from the file
+    search_patterns = []
+    search_patterns.append("  Norm reduction all members .")
+    search_patterns.append("  Quadratic cost function all members: J .")
+
+    # Labels for the figures
+    ylabels = []
+    ylabels.append(minimizer+" normalized gradient reduction")
+    ylabels.append("Quadratic cost function J   ")
+
+    # Get all lines that match the search patterns
+    matches = []
+    for line in file:
+        for search_pattern in search_patterns:
+            reg = re.compile(search_pattern) 
+            if bool(re.match(reg, line.rstrip())):
+                matches.append(line.rstrip())
+
+    # Close the file
+    file.close()
+
+    # Loop over stats to be searched on
+    maxiterations = 10000
+    count = np.zeros(len(search_patterns), dtype=int)
+    stats = np.zeros((len(search_patterns), maxiterations))
+    for search_pattern in search_patterns:
+
+        index = [i for i, s in enumerate(search_patterns) if search_pattern in s]
+
+        # Loop over the matches and fill stats
+        for match in matches:
+
+            reg = re.compile(search_pattern)
+            print("this is a match")
+            print(match)
+            if bool(re.match(reg, match)):
+
+                stats[index,count[index]] = match.split()[-1]
+                count[index] = count[index] + 1
+                print("this is what is found:"+str(stats[index,count[index]]))
+
+    niter = count[0]
+    stat = np.zeros(niter)
+
+
+    # Create figures
+    # --------------
+
+    # Scale for y-axis
+    try:
+        yscale = conf['yscale']
+    except:
+        yscale = 'linear'
+
+    # Format for plots
+    try:
+        plotformat = conf['plot format']
+    except:
+        plotformat = 'png'
+
+    for ylabel in ylabels:
+
+        index = [i for i, s in enumerate(ylabels) if ylabel in s]
+        savename = ylabel.lower().strip()
+        savename = savename.replace(" ", "-")
+        savename = savename+"_"+datetime.strftime("%Y%m%d_%H%M%S")+"."+plotformat
+        savename = os.path.join(output_path,savename)
+
+        stat[0:niter] = stats[index,0:niter]
+        stat_plot = stat[np.nonzero(stat)]
+
+        iter = np.arange(1, len(stat_plot)+1)
+
+        fig, ax = plt.subplots(figsize=(15, 7.5))
+        ax.plot(iter, stat_plot, linestyle='-', marker='x')
+        ax.tick_params(labelbottom=True, labeltop=False, labelleft=True, labelright=True)
+        plt.title("JEDI variational assimilation convergence statistics | "+isodatestr)
+        plt.xlabel("Iteration number")
+        plt.ylabel(ylabel)
+        plt.yscale(yscale)
+
+        print(" Saving figure as", savename, "\n")
+        plt.savefig(savename)
+
+# --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Adds a tool to plot convergence of QuadJ + norm gradient for the block Lanczos algorithm.

### Issue(s) addressed

- fixes https://github.com/JCSDA-internal/oops/issues/872

I am not sure how to add an actual log file, it seems in the other yaml files it points to a location somewhere outside this repo.

The figures for the qg block test look like this: 

The cost function:
![block_testquadratic-cost-function-j](https://user-images.githubusercontent.com/43183478/118334464-e303c280-b4ca-11eb-9f5b-d32eb93132cd.png)

And the norm gradient:
![block_testdrpblocklanczos-normalized-gradient-reduction](https://user-images.githubusercontent.com/43183478/118334473-e72fe000-b4ca-11eb-88ee-4bf238458679.png)

